### PR TITLE
feat: allow home page content customization

### DIFF
--- a/app/Filament/Resources/SiteSettings/Schemas/SiteSettingForm.php
+++ b/app/Filament/Resources/SiteSettings/Schemas/SiteSettingForm.php
@@ -73,7 +73,19 @@ class SiteSettingForm
                     ->label('Email address')
                     ->email(),
                 TextInput::make('headline'),
+                Textarea::make('subheadline'),
                 TextInput::make('hero_video_url'),
+                Fieldset::make('Homepage Stats')->schema([
+                    TextInput::make('stat_years')->label('Years'),
+                    TextInput::make('stat_projects')->label('Projects'),
+                    TextInput::make('stat_emr')->label('Safety EMR'),
+                ])->columns(3),
+                Fieldset::make('Call to Action')->schema([
+                    TextInput::make('cta_heading'),
+                    Textarea::make('cta_text')->columnSpanFull(),
+                    TextInput::make('cta_button_text'),
+                    TextInput::make('cta_button_url'),
+                ]),
                 Textarea::make('social_links')
                     ->columnSpanFull(),
                 TextInput::make('theme')

--- a/app/Models/SiteSetting.php
+++ b/app/Models/SiteSetting.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 class SiteSetting extends Model
 {
     protected $fillable = [
-        'site_name','logo_path','primary_color','secondary_color','address','phone','email','headline','hero_video_url','social_links','theme',
+        'site_name','logo_path','primary_color','secondary_color','address','phone','email','headline','subheadline','hero_video_url','social_links','theme','stat_years','stat_projects','stat_emr','cta_heading','cta_text','cta_button_text','cta_button_url',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_09_07_000002_add_home_page_fields_to_site_settings_table.php
+++ b/database/migrations/2025_09_07_000002_add_home_page_fields_to_site_settings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('site_settings', function (Blueprint $table) {
+            $table->text('subheadline')->nullable();
+            $table->string('stat_years')->nullable();
+            $table->string('stat_projects')->nullable();
+            $table->string('stat_emr')->nullable();
+            $table->string('cta_heading')->nullable();
+            $table->text('cta_text')->nullable();
+            $table->string('cta_button_text')->nullable();
+            $table->string('cta_button_url')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('site_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'subheadline',
+                'stat_years',
+                'stat_projects',
+                'stat_emr',
+                'cta_heading',
+                'cta_text',
+                'cta_button_text',
+                'cta_button_url',
+            ]);
+        });
+    }
+};

--- a/database/seeders/DemoContentSeeder.php
+++ b/database/seeders/DemoContentSeeder.php
@@ -23,6 +23,14 @@ class DemoContentSeeder extends Seeder
         SiteSetting::firstOrCreate([], [
             'site_name' => 'Lombii Construction',
             'headline' => 'Making a difference in how the world is built.',
+            'subheadline' => 'From preconstruction to delivery, we provide end‑to‑end construction services across markets.',
+            'stat_years' => '25+',
+            'stat_projects' => '500+',
+            'stat_emr' => '0.62',
+            'cta_heading' => 'Ready to build something great?',
+            'cta_text' => 'Let’s discuss your project and how we can help.',
+            'cta_button_text' => 'Get in touch',
+            'cta_button_url' => '/contact',
             'primary_color' => '#10b981',
             'secondary_color' => '#0ea5e9',
         ]);

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -16,7 +16,7 @@
                         {{ $settings->headline ?? 'Building the future with precision and care.' }}
                     </h1>
                     <p class="mt-4 text-slate-300 text-lg max-w-prose">
-                        From preconstruction to delivery, we provide end‑to‑end construction services across markets.
+                        {{ $settings->subheadline ?? 'From preconstruction to delivery, we provide end‑to‑end construction services across markets.' }}
                     </p>
                     <div class="mt-8 flex items-center gap-4">
                         <a href="/projects" class="px-6 py-3 rounded-lg bg-emerald-500 text-slate-900 font-semibold hover:bg-emerald-400 transition">Explore Projects</a>
@@ -25,15 +25,15 @@
                     <dl class="mt-10 grid grid-cols-3 gap-6 text-center">
                         <div class="p-4 rounded-xl bg-white/5 border border-white/10" data-aos="zoom-in">
                             <dt class="text-sm text-slate-400">Years</dt>
-                            <dd class="mt-1 text-3xl font-bold">25+</dd>
+                            <dd class="mt-1 text-3xl font-bold">{{ $settings->stat_years ?? '25+' }}</dd>
                         </div>
                         <div class="p-4 rounded-xl bg-white/5 border border-white/10" data-aos="zoom-in" data-aos-delay="100">
                             <dt class="text-sm text-slate-400">Projects</dt>
-                            <dd class="mt-1 text-3xl font-bold">500+</dd>
+                            <dd class="mt-1 text-3xl font-bold">{{ $settings->stat_projects ?? '500+' }}</dd>
                         </div>
                         <div class="p-4 rounded-xl bg-white/5 border border-white/10" data-aos="zoom-in" data-aos-delay="200">
                             <dt class="text-sm text-slate-400">Safety EMR</dt>
-                            <dd class="mt-1 text-3xl font-bold">0.62</dd>
+                            <dd class="mt-1 text-3xl font-bold">{{ $settings->stat_emr ?? '0.62' }}</dd>
                         </div>
                     </dl>
                 </div>
@@ -186,10 +186,10 @@
         <div class="shine-border rounded-2xl p-0.5" data-aos="zoom-in">
             <div class="rounded-2xl bg-gradient-to-br from-emerald-500/10 to-sky-500/10 px-6 py-10 md:px-10 md:py-12 flex flex-col md:flex-row items-center justify-between gap-6">
                 <div>
-                    <h3 class="text-2xl md:text-3xl font-bold">Ready to build something great?</h3>
-                    <p class="text-slate-300 mt-2">Let’s discuss your project and how we can help.</p>
+                    <h3 class="text-2xl md:text-3xl font-bold">{{ $settings->cta_heading ?? 'Ready to build something great?' }}</h3>
+                    <p class="text-slate-300 mt-2">{{ $settings->cta_text ?? 'Let’s discuss your project and how we can help.' }}</p>
                 </div>
-                <a href="/contact" class="px-6 py-3 rounded-lg bg-emerald-500 text-slate-900 font-semibold hover:bg-emerald-400 transition">Get in touch</a>
+                <a href="{{ $settings->cta_button_url ?? '/contact' }}" class="px-6 py-3 rounded-lg bg-emerald-500 text-slate-900 font-semibold hover:bg-emerald-400 transition">{{ $settings->cta_button_text ?? 'Get in touch' }}</a>
             </div>
         </div>
     </section>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,7 +11,9 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="{{ $settings->primary_color ?? '#10b981' }}" />
     <link rel="canonical" href="{{ url()->current() }}" />
-    @vite(['resources/css/app.css','resources/js/app.js'])
+    @if (file_exists(public_path('build/manifest.json')))
+        @vite(['resources/css/app.css','resources/js/app.js'])
+    @endif
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic test example.
      */


### PR DESCRIPTION
## Summary
- make site settings manage home page subheadline, stats, and CTA details
- expose new settings in Filament admin panel
- render home page sections using stored settings and seed defaults
- ensure tests run migrations and skip Vite assets when build missing

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68c10badf57883239b4eaaa907fea641