### PR TITLE
Install intl extension for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,14 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libxml2-dev \
     libzip-dev \
+    libicu-dev \
     zip \
     unzip \
     nodejs \
     npm \
     supervisor \
     cron \
-    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip \
+    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd zip intl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -42,8 +43,9 @@ RUN chown -R www-data:www-data /var/www/html \
     && chmod -R 755 /var/www/html/storage \
     && chmod -R 755 /var/www/html/bootstrap/cache
 
-# Install PHP dependencies
-RUN composer install --optimize-autoloader --no-dev --no-interaction
+# Configure Git and install PHP dependencies
+RUN git config --global --add safe.directory /var/www/html \
+    && composer install --optimize-autoloader --no-dev --no-interaction
 
 # Install Node dependencies and build assets
 RUN npm ci && npm run build && npm cache clean --force


### PR DESCRIPTION
## Summary
- Install PHP intl extension and required libicu-dev in Dockerfile
- Configure Git safe directory before installing Composer dependencies

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c15831bdf88323bec036a87fe0a0c5